### PR TITLE
fix(security): 使用随机令牌限制 qzone-local 文件访问

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,6 +4,7 @@ import { Readable } from 'stream'
 import { ApplicationBootstrapper } from '@main/app-bootstrapper'
 import { optimizer, electronApp, platform, is } from '@electron-toolkit/utils'
 import logger from '@main/core/logger'
+import { resolveLocalMedia } from '@main/utils/local-media-registry'
 import { APP_ID } from '@shared/const'
 
 // 开发环境远程调试端口
@@ -34,13 +35,17 @@ const bootstrapper = new ApplicationBootstrapper()
 app.whenReady().then(async () => {
   try {
     // 注册 qzone-local:// → 本地文件，用 fs.createReadStream 流式响应，无内存占用
-    // 格式约定：qzone-local://local/<encoded-abs-path>
+    // 格式约定：qzone-local://local/<token>
     // 支持 Range 请求（HTML5 video 加载视频时会发 Range）
     // 主窗口用 partition: 'persist:qzone'，必须在该 session 上注册（partition session 不继承 default）
     const qzoneSession = session.fromPartition('persist:qzone')
     const handleProtocol = async (req) => {
       const u = new URL(req.url)
-      const filePath = decodeURIComponent(u.pathname.replace(/^\//, ''))
+      const token = u.pathname.replace(/^\//, '')
+      const filePath = resolveLocalMedia(token)
+      if (!filePath) {
+        return new Response('Not found', { status: 404 })
+      }
       try {
         const stat = await fs.promises.stat(filePath)
         const range = req.headers.get('range')

--- a/src/main/ipc/modules/file.ipc.js
+++ b/src/main/ipc/modules/file.ipc.js
@@ -1,6 +1,7 @@
 import { dialog } from 'electron'
 import { getFileInfo } from '@main/utils/file-processor'
 import { getVideoMetadata } from '@main/services/video-metadata'
+import { registerLocalMedia } from '@main/utils/local-media-registry'
 import { IPC_FILE } from '@shared/ipc-channels'
 import fs from 'fs'
 import path from 'path'
@@ -90,8 +91,8 @@ export function createFileHandlers() {
         }
         // 不再 readFileSync 整文件转 base64（GB 级视频会让主进程 V8 ExternalMemoryAccounter 崩溃）
         // 返回 qzone-local:// 协议 URL，让 renderer <video> 标签流式加载
-        const normalized = filePath.replace(/\\/g, '/')
-        const dataUrl = 'qzone-local://local/' + encodeURIComponent(normalized)
+        const token = registerLocalMedia(filePath)
+        const dataUrl = `qzone-local://local/${token}`
         return { dataUrl }
       } catch (error) {
         console.error('获取视频预览失败:', error)

--- a/src/main/utils/local-media-registry.js
+++ b/src/main/utils/local-media-registry.js
@@ -1,0 +1,20 @@
+import crypto from 'crypto'
+import path from 'path'
+
+const tokenToPath = new Map()
+const pathToToken = new Map()
+
+export function registerLocalMedia(filePath) {
+  const normalizedPath = path.resolve(filePath)
+  const existingToken = pathToToken.get(normalizedPath)
+  if (existingToken) return existingToken
+
+  const token = crypto.randomUUID()
+  tokenToPath.set(token, normalizedPath)
+  pathToToken.set(normalizedPath, token)
+  return token
+}
+
+export function resolveLocalMedia(token) {
+  return tokenToPath.get(token) || null
+}


### PR DESCRIPTION
## 背景

`qzone-local://` 协议原先将本地绝对路径直接编码在 URL 中。

例如：

```text
qzone-local://local/<encoded-absolute-path>
```

协议处理器会解码 URL 并直接读取对应文件，因此任意能够构造该协议 URL 的页面都可以尝试访问当前用户权限范围内的本地路径。

## 修改内容

本 PR 将协议地址改为基于随机 UUID token 的形式：

```text
qzone-local://local/<token>
```

具体包括：

- 新增进程内的 token 与文件路径映射
- 视频预览接口为文件签发随机 token
- `qzone-local` 协议只解析已注册的 token
- 未注册或无效 token 返回 404
- 同一文件复用已有 token，避免重复创建映射

本地绝对路径不再出现在协议 URL 中，也不能再通过构造 URL 直接指定需要读取的路径。

## 兼容性

本次修改保持现有前端 API 和返回结构不变，渲染进程仍然使用返回的 `dataUrl` 播放视频。

## 测试

- [x] 照片预览正常
- [x] 视频预览和播放正常
- [x] 视频进度跳转正常
- [x] token 为随机 UUID
- [x] 同一路径复用相同 token
- [x] 无效 token 无法解析
- [x] 旧的绝对路径 URL 返回 404
- [x] `pnpm build` 通过
- [x] ESLint 无新增错误

## 说明

token 映射仅保存在主进程内存中，应用退出后会自动失效，不会持久化本地文件路径或 token。
